### PR TITLE
better handling of column names in kd()

### DIFF
--- a/semTools/R/kd.R
+++ b/semTools/R/kd.R
@@ -115,6 +115,10 @@ kd <- function(covmat, n, type=c("exact","sample")) {
   ## Scale data to correspond to covmat
   dat <- t(dat) %*% mv.vars
 
+  ## convert to data.frame, use any existing names from covmat
+  dat <- data.frame(dat)
+  if(!is.null(colnames(covmat))) names(dat) <- colnames(covmat)
+  
   dat
 }
 


### PR DESCRIPTION
A long time ago on the lavaan list, somebody asked to have kd() use any existing colnames associated with the input argument covmat. This push does that: if you send in a covmat with non-null colnames, then you get out a data.frame that uses the colnames. If the covmat has null colnames, you still get a data.frame out.

In case it matters, the lavaan list subject was "lavaan Error: missing observed variables in dataset"