### PR TITLE
getFitSummary - error in rownames(diffTab)?

### DIFF
--- a/semTools/R/compareFit.R
+++ b/semTools/R/compareFit.R
@@ -428,7 +428,7 @@ getFitSummary <- function(object, fit.measures = "default", return.diff = FALSE)
 
   ## or return differences in fit indices
   diffTab <- as.data.frame(do.call(cbind, lapply(fitTab, diff)))
-  rownames(diffTab) <- paste(object@name[-1], "-", object@name[-nrow(diffTab)])
+  rownames(diffTab) <- paste(object@name[-1], "-", object@name[-length(object@name)])
   diffTab
 }
 


### PR DESCRIPTION
diffTab is 1 element shorter than object@name. Therefore, `object@name[-nrow(diffTab)] `does not delete the last element of `object@name`, but the next-to-last. 

Does this make sense?