### PR TITLE
missing evaluation in summary--measEq.syntax

### DIFF
--- a/semTools/R/measEq.R
+++ b/semTools/R/measEq.R
@@ -312,8 +312,9 @@ setMethod("summary", "measEq.syntax", function(object, verbose = TRUE) {
   cat('\n')
 
   ## without any constraints, call it the configural model
-  if (length(object@call$group.equal) == 1L && object@call$group.equal == "" &&
-      length(object@call$long.equal) == 1L && object@call$long.equal == "") {
+  group_configural <- all(eval(object@call$group.equal) %in% c("", NULL))
+  long_configural <-  all(eval(object@call$long.equal) %in% c("", NULL))
+  if(group_configural & long_configural) {
     cat('\nThis model hypothesizes only configural invariance.\n\n')
     ## return pattern matrix
     return(invisible(lambda))
@@ -322,13 +323,13 @@ setMethod("summary", "measEq.syntax", function(object, verbose = TRUE) {
 
   ## constrained parameters across groups (+ partial exceptions)
   if (nG > 1L) {
-    if (length(object@call$group.equal) == 1L && object@call$group.equal == "") {
+    if(group_configural) {
       cat('No parameters were constrained to equality across groups.\n')
     } else {
       cat('The following types of parameter were constrained to',
           'equality across groups:\n\n')
-      for (i in object@call$group.equal) {
-        group.partial <- object@call$group.partial
+      for (i in eval(object@call$group.equal)) {
+        group.partial <- eval(object@call$group.partial)
         ## first, check for exceptions
         if (i == "loadings") {
           man.ind <- group.partial$rhs %in% rownames(object@specify[[1]]$lambda)
@@ -389,12 +390,12 @@ setMethod("summary", "measEq.syntax", function(object, verbose = TRUE) {
   }
   ## constrained parameters across repeated measures (+ partial exceptions)
   if (length(object@call$longFacNames)) {
-    if (length(object@call$long.equal) == 1L && object@call$long.equal == "") {
+    if(long_configural) {
       cat('No parameters were constrained to equality across repeated measures:\n')
     } else {
       cat('The following types of parameter were constrained to equality',
           'across repeated measures:\n\n')
-      for (i in object@call$long.equal) {
+      for (i in eval(object@call$long.equal)) {
         long.partial <- object@call$long.partial
         ## first, check for exceptions
         if (i == "loadings") {

--- a/semTools/R/measEq.R
+++ b/semTools/R/measEq.R
@@ -834,6 +834,8 @@ measEq.syntax <- function(configural.model, ..., ID.fac = "std.lv",
                           warn = TRUE, debug = FALSE, return.fit = FALSE) {
 
   mc <- match.call(expand.dots = TRUE)
+  mc$group.equal <- call("c", eval(group.equal))
+  mc$long.equal <- call("c", eval(long.equal))
 
   ## -------------------------------
   ## Preliminary checks on arguments


### PR DESCRIPTION
Problem: 
in `summary--measEq.syntax`: elements in `object@call`, e.g. `object@call$group.equal` may be unevaluated. 
Example (from help): 
```
mod.cat <- ' FU1 =~ u1 + u2 + u3 + u4
             FU2 =~ u5 + u6 + u7 + u8 '
longFacNames <- list(FU = c("FU1","FU2"))


test.seq <- c("thresholds","loadings","intercepts","means","residuals")
meq.list <- list()
for (i in 0:length(test.seq)) {
  if (i == 0L) {
    meq.label <- "configural"
    group.equal <- ""
    long.equal <- ""
  } else {
    meq.label <- test.seq[i]
    group.equal <- test.seq[1:i]
    long.equal <- test.seq[1:i]
  }
  meq.list[[meq.label]] <- measEq.syntax(configural.model = mod.cat,
                                         data = datCat,
                                         ordered = paste0("u", 1:8),
                                         parameterization = "theta",
                                         ID.fac = "std.lv",
                                         ID.cat = "Wu.Estabrook.2016",
                                         group = "g",
                                         group.equal = group.equal,
                                         longFacNames = longFacNames,
                                         long.equal = long.equal,
                                         return.fit = FALSE)
}
```
Calling `summary(meq.list$configural)` fails with `Error in for (i in object@call$group.equal) { : 
  invalid for() loop sequence` 
Solution: 
Force evaluation by explicitly calling `eval`.