### PR TITLE
Discriminant validity paper is out, citation added

### DIFF
--- a/semTools/DESCRIPTION
+++ b/semTools/DESCRIPTION
@@ -1,3 +1,4 @@
+Encoding:UTF-8
 Package: semTools
 Version: 0.5-3.910
 Title: Useful Tools for Structural Equation Modeling
@@ -25,7 +26,8 @@ Authors@R: c(person(given = c("Terrence","D."), family = "Jorgensen", role = c("
 		person(given = c("Jason","D."), family = "Rights", role = "ctb", email="jrights@psych.ubc.ca"),
 		person(given = "Ylenio", family = "Longo", role = "ctb", email="yleniolongo@gmail.com"),
 		person(given = "Maxwell", family = "Mansolf", role = "ctb", email="mamansolf@gmail.com", comment = c(ORCID = "0000-0001-6861-8657")),
-		person(given = "Mattan S.", family = "Ben-Shachar", role = "ctb", email="matanshm@post.bgu.ac.il", comment = c(ORCID = "0000-0002-4287-4801"))
+		person(given = "Mattan S.", family = "Ben-Shachar", role = "ctb", email="matanshm@post.bgu.ac.il", comment = c(ORCID = "0000-0002-4287-4801")),
+		person(given = "Mikko", family = "Rönkkö", role = "ctb", email = "mikko.ronkko@jyu.fi", comment = c(ORCID = "0000-0001-7988-7609"))
 		)
 Depends: R(>= 3.4), utils, stats, graphics, lavaan(>= 0.6-6)
 Imports: methods

--- a/semTools/R/discriminantValidity.R
+++ b/semTools/R/discriminantValidity.R
@@ -1,5 +1,5 @@
-### Mikko Ronkko
-### Last updated: 3 December 2019
+### Mikko Rönkkö
+### Last updated: 1 December 2020
 
 
 ##' Calculate discriminant validity statistics
@@ -15,7 +15,7 @@
 ##' are commonly used in discriminant validity evaluation. The first set are
 ##' factor correlation estimates and their confidence intervals. The second set
 ##' is a series of nested model tests, where the baseline model is compared
-##' against as set of constrained models that are constructed by constraining
+##' against a set of constrained models that are constructed by constraining
 ##' each factor correlation to the specified cutoff one at a time.
 ##'
 ##' The function assume that the \code{object} is set of confirmatory
@@ -66,12 +66,13 @@
 ##'  used in the likelihood ratio test.}
 ##' }
 ##'
-
-## @author ADD MIKKO AFTER ARTICLE IS ACCEPTED, also add to DESCRIPTION:
-## person(given = "Mikko", family = "Ronkko", role = "ctb", email = "mikko.ronkko@jyu.fi", comment = c(ORCID = "0000-0001-7988-7609")),
-
-## @references ADD CITATION AFTER ARTICLE HAS A DOI
-
+##' @author
+##'  Mikko Rönkkö (University of Jyväskylä; \email{mikko.ronkko@jyu.fi}):
+##' @references
+##'
+##' Rönkkö, M., & Cho, E. (2020). An updated guideline for assessing
+##' discriminant validity. \emph{Organizational Research Methods}.
+##' \url{https://doi.org/10.1177/1094428120968614}
 ##'
 ##' @examples
 ##'

--- a/semTools/man/discriminantValidity.Rd
+++ b/semTools/man/discriminantValidity.Rd
@@ -41,7 +41,7 @@ representing two distinct constructs.
 are commonly used in discriminant validity evaluation. The first set are
 factor correlation estimates and their confidence intervals. The second set
 is a series of nested model tests, where the baseline model is compared
-against as set of constrained models that are constructed by constraining
+against a set of constrained models that are constructed by constraining
 each factor correlation to the specified cutoff one at a time.
 
 The function assume that the \code{object} is set of confirmatory
@@ -84,4 +84,12 @@ fit <- cfa(HS.model, data = HolzingerSwineford1939)
 discriminantValidity(fit)
 discriminantValidity(fit, merge = TRUE)
 
+}
+\references{
+Rönkkö, M., & Cho, E. (2020). An updated guideline for assessing
+discriminant validity. \emph{Organizational Research Methods}.
+\url{https://doi.org/10.1177/1094428120968614}
+}
+\author{
+Mikko Rönkkö (University of Jyväskylä; \email{mikko.ronkko@jyu.fi}):
 }


### PR DESCRIPTION
I wrote the discriminantValidity function when I was working on a paper for Organizational Research Methods. The paper is now out and will be available as open access after we get the APC processed. I added a citation to the paper to the function documentation. I also changed the encoding to UTF-8 to support my name, which has o characters with dots over them and added myself to contributors in DESCRIPTION.