### PR TITLE
Patch auxiliary.R

### DIFF
--- a/semTools/R/auxiliary.R
+++ b/semTools/R/auxiliary.R
@@ -96,6 +96,9 @@ auxiliary <- function(model, data, aux, fun, ...) {
   lavArgs$meanstructure <- TRUE
   lavArgs$ordered <- NULL
 
+  # Get environment for lavaan (assumes always lavaan function in package)
+  lavaanEnv <- environment(lavaan::lavaan)
+
   if (missing(aux))
     stop("Please provide a character vector with names of auxiliary variables")
   if (missing(data))
@@ -118,7 +121,7 @@ auxiliary <- function(model, data, aux, fun, ...) {
 	    startArgs <- lavArgs
 	    startArgs$model <- model
 	    startArgs$do.fit <- FALSE
-	    model$start <- parTable(do.call(fun, startArgs))$start
+	    model$start <- parTable(do.call(fun, startArgs, envir = lavaanEnv))$start
 	  }
 
 	  missingCols <- setdiff(PTcols, names(model))
@@ -130,7 +133,7 @@ auxiliary <- function(model, data, aux, fun, ...) {
 	  ptArgs <- lavArgs
 	  ptArgs$model <- model
 	  ptArgs$do.fit <- FALSE
-	  PT <- parTable(do.call(fun, ptArgs))[PTcols]
+	  PT <- parTable(do.call(fun, ptArgs, envir = lavaanEnv))[PTcols]
 	} else stop("The 'model' argument must be a character vector of",
 	            " lavaan syntax or a parameter table")
 
@@ -187,7 +190,7 @@ auxiliary <- function(model, data, aux, fun, ...) {
 	#   mergedPT$start[newRows] <- startVals
 	# }
 	lavArgs$model <- lavaan::lav_partable_complete(rbind(mergedPT, CON))
-  result <- do.call(fun, lavArgs)
+  result <- do.call(fun, lavArgs, envir = lavaanEnv)
 
   ## specify, fit, and attach an appropriate independence model
   baseArgs <- list()
@@ -206,7 +209,7 @@ auxiliary <- function(model, data, aux, fun, ...) {
   baseArgs$control                <- lavArgs$control
   baseArgs$optim.method           <- lavArgs$optim.method
 
-  result@external$baseline.model  <- do.call(lavaan::lavaan, baseArgs)
+  result@external$baseline.model  <- do.call(lavaan::lavaan, baseArgs, envir = lavaanEnv)
   result@external$aux             <- aux
   result@external$baseline.syntax <- satMod
 	result


### PR DESCRIPTION
Patches auxiliary.R to work when the lavaan package or semTools package has not been loaded via a library function call.

Currently, if lavaan's namespace isn't loaded, then  `do.call` will throw an error. This prevents being able to do calls like `semTools::auxiliary()`