### PR TITLE
make emmeans more robust to different parameter names

### DIFF
--- a/semTools/R/emmeans_lavaan.R
+++ b/semTools/R/emmeans_lavaan.R
@@ -108,7 +108,7 @@ recover_data.lavaan <- function(object, lavaan.DV, ...){
   if (anyNA(lavaan_data)) {
     warning(
       "Data used for modeling contains missing values.",
-      "\n  Concider setting the `at = ` argument explicitly" ,
+      "\n  Consider setting the `at = ` argument explicitly" ,
       "\n  or pass a function(s) that deals with missing values to",
       "\n  the `cov.reduce = ` argument. ", call. = FALSE
     )

--- a/semTools/man/lavaan2emmeans.Rd
+++ b/semTools/man/lavaan2emmeans.Rd
@@ -63,7 +63,11 @@ the name matching the \code{group} argument supplied when fitting the model.
 
 \subsection{Dealing with Missing Data}{
 Limited testing suggests that these functions do work when the model was fit
-to incomplete data.
+to incomplete data. However, when FIML is used, the default method for
+\code{\link[emmeans:ref_grid]{cov.reduce}} might fail; We recommend that
+users explicitly set either the \code{at = } argument or the
+\code{cov.reduce = } argument with a function (or functions) that properly
+deal with missing data.
 }
 
 \subsection{Dealing with Factors}{


### PR DESCRIPTION
This PR is meant to allow `emmeans` support to be robust to the term order in an interaction term in `lavaan`.

For example, now `emmeans` will give the same results for all 4 interaction regressions:

- `y ~ a + b + a:b`
- `y ~ a + b + b:a`
- `y ~ b + a + a:b`
- `y ~ b + a + b:a`
