### PR TITLE
fix bug with `nullRMSEA` requiring data in global environment

### DIFF
--- a/semTools/R/fitIndices.R
+++ b/semTools/R/fitIndices.R
@@ -389,7 +389,11 @@ moreFitIndices <- function(object, fit.measures = "all", nPrior = 1) {
 ##'
 ##' @export
 nullRMSEA <- function(object, scaled = FALSE, silent = FALSE) {
-  fit <- lavaan::update(object, model = lavaan::lav_partable_independence(object))
+  fit <- lavaan::update(
+    object,
+    model = lavaan::lav_partable_independence(object),
+    data = object@Data
+  )
 	fits <- lavaan::fitMeasures(fit, fit.measures = c("rmsea","rmsea.scaled",
 	                                                  "rmsea.robust"))
 	if (scaled) {


### PR DESCRIPTION
This fixes a bug where `nullRMSEA ` (i.e., used in `moreFitIndices`) relies on the data set in the global environment. If the data set does not exist there, currently, there is a nondescriptive error message. For example, if the model is generated within a function currently, there is an error:

```r
# Minimal Working Example
library(semTools)
library(lavaan)
fit_model <- function() {
    set.seed(98123)
    # Generate Data
    f <- rnorm(100)
    mydata <- data.frame(
        x1 = rnorm(100, f, 1),
        x2 = rnorm(100, f, 1),
        x3 = rnorm(100, f, 1)
    )
    # Fit Model and return
    cfa("f  =~ x1 + x2 + x3", data = mydata)
}

fit <- fit_model()
moreFitIndices(fit) # This throws errors
# Error in eval(call, parent.frame()) : object 'mydata' not found
```

Another example is if the `moreFitIndices` is called even within the function:

```r
# Minimal Working Example
library(semTools)
library(lavaan)
fit_model <- function() {
    set.seed(98123)
    # Generate Data
    f <- rnorm(100)
    mydata <- data.frame(
        x1 = rnorm(100, f, 1),
        x2 = rnorm(100, f, 1),
        x3 = rnorm(100, f, 1)
    )
    # Fit Model
    fit <- cfa("f  =~ x1 + x2 + x3", data = mydata)
    # Return fit indices
    moreFitIndices(fit) # Errors
    # Error in eval(call, parent.frame()) : object 'mydata' not found
}

fit_ind <- fit_model()
```

This issue can be problematic when trying to use the function in something like a simulation.
The proposed fix forces `nullRMSEA` to use the data set stored in the lavaan object.
