### PR TITLE
Deal with missing values

### DIFF
--- a/semTools/R/emmeans_lavaan.R
+++ b/semTools/R/emmeans_lavaan.R
@@ -551,17 +551,29 @@ grade ~ ageyr
   })
 
 
-  testthat::test_that("missing data - warn", {
-    utils::data("mtcars")
-    mtcars$hp[1] <- NA
+  testthat::test_that("missing data", {
+    data("mtcars")
+    raw_mtcars <- mtcars_na <- mtcars
+    mtcars_na$hp[1] <- NA
 
     model <- " mpg ~ hp + drat + hp:drat "
 
-    fit <- lavaan::sem(model, mtcars, missing = "fiml.x")
+    fit <- lavaan::sem(model, mtcars_na, missing = "fiml.x")
 
     testthat::expect_warning(
-      emmeans::ref_grid(fit, lavaan.DV = "mpg")
-    )
+      rg <- emmeans::ref_grid(fit, lavaan.DV = "mpg"),
+      regexp = "missing")
+
+    testthat::expect_false(anyNA(rg@grid))
+    testthat::expect_equal(rg@grid$hp, 147.871, tolerance = 0.01)
+
+
+    testthat::expect_warning(
+      rg2 <- emmeans::ref_grid(fit, lavaan.DV = "mpg",
+                               data = raw_mtcars),
+      regexp = NA)
+
+    testthat::expect_equal(rg2@grid$hp, mean(raw_mtcars$hp), tolerance = 0.01)
   })
 
 


### PR DESCRIPTION
Following #119 - this provides two solutions to missing values:

1. Mean impute them (default)
2. Allow users to pass the `data=` argument

``` r
library(semTools)
library(emmeans)


data("mtcars")
raw_mtcars <- mtcars
mtcars$hp[1] <- NA
model <- " mpg ~ hp + drat + hp:drat "
fit <- sem(model, mtcars, missing = "fiml.x")




ref_grid(fit, lavaan.DV = "mpg")
#> Warning: 'data' contains missing value. Mean-imputing them.
#> 'emmGrid' object with variables:
#>     hp = 147.87
#>     drat = 3.5966


ref_grid(fit, lavaan.DV = "mpg",
         data = raw_mtcars)
#> 'emmGrid' object with variables:
#>     hp = 146.69
#>     drat = 3.5966

emtrends(fit, ~ drat, var = "hp", lavaan.DV = "mpg",
         data = raw_mtcars)
#>  drat hp.trend      SE  df asymp.LCL asymp.UCL
#>   3.6  -0.0506 0.00899 Inf   -0.0682    -0.033
#> 
#> Confidence level used: 0.95
```

<sup>Created on 2025-02-10 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
