### PR TITLE
fix environment in parallel clusterExport in permuteMeasEq

### DIFF
--- a/semTools/R/permuteMeasEq.R
+++ b/semTools/R/permuteMeasEq.R
@@ -973,7 +973,7 @@ permuteMeasEq <- function(nPermute, modelType = c("mgcfa","mimic"),
     argList$cl <- cl
     argList$X <- 1:nPermute
     argList$fun <- paste("permuteOnce", modelType, sep = ".")
-    parallel::clusterExport(cl, varlist = c(argList$fun, "getAFIs","getMIs")) #FIXME: need update?
+    parallel::clusterExport(cl, varlist = c(argList$fun, "getAFIs","getMIs"), envir = asNamespace("semTools"))
 	tempppl <- function(...) { parallel::parLapply(...) }
     permuDist <- do.call(tempppl, args = argList)
     if (stopTheCluster) parallel::stopCluster(cl)


### PR DESCRIPTION
Small tweak to import `semTools` in the `parallel::clusterExport` as a minimal fix to enable `snow` for `permuteMeasEq`, fixing #95. Confirmed that their repex runs without error with this change. I know elsewhere you discussed overhauling permuteMeasEq, but this may be an ok stopgap in the meantime.