### PR TITLE
Wrap getAFIs and getMIs calls in permuteOnce.mgcfa and permuteOnce.mimic with tryCatch (closes #159)

### DIFF
--- a/semTools/R/permuteMeasEq.R
+++ b/semTools/R/permuteMeasEq.R
@@ -1412,22 +1412,37 @@ permuteOnce.mgcfa <- function(i, d, G, con, uncon, null, param, freeParam,
     availableArgs$con <- out0
     if (exists("out1")) availableArgs$uncon <- out1
     if (exists("out.null")) availableArgs$null <- out.null
-    AFI <- do.call(getAFIs, availableArgs)
+    # Wrap getAFIs so a failure doesn't kill the worker
+    AFI <- tryCatch(
+      do.call(getAFIs, availableArgs),
+      error = function(e) {
+        allAFIs <- c(AFIs, moreAFIs)
+        out <- rep(NA_real_, sum(!is.na(allAFIs)))
+        names(out) <- allAFIs[!is.na(allAFIs)]
+        out
+      }
+    )
     ## save max(MI) if !is.null(param)
     if (is.null(param)) {
       MI <- NULL
     } else {
-      MI <- max(do.call(getMIs, c(availableArgs, modelType = "mgcfa"))$X2)
+      # Wrap getMIs so a failure doesn't kill the worker
+      MI <- tryCatch(
+        max(do.call(getMIs, c(availableArgs, modelType = "mgcfa"))$X2),
+        error = function(e) NA_real_
+      )
     }
     ## anything extra?
     if (!is.null(extra)) {
-      extraArgs <- formals(extra)
-      neededArgs <- intersect(names(extraArgs), names(availableArgs))
-      extraArgs <- do.call(c, lapply(neededArgs, function(nn) availableArgs[nn]))
-      extraOut <- do.call(extra, extraArgs)
-      ## coerce extraOut to data.frame
-      if (!is.list(extraOut)) extraOut <- as.list(extraOut)
-      extra.obs <- data.frame(extraOut)
+      extra.obs <- tryCatch({
+        extraArgs <- formals(extra)
+        neededArgs <- intersect(names(extraArgs), names(availableArgs))
+        extraArgs <- do.call(c, lapply(neededArgs, function(nn) availableArgs[nn]))
+        extraOut <- do.call(extra, extraArgs)
+        ## coerce extraOut to data.frame
+        if (!is.list(extraOut)) extraOut <- as.list(extraOut)
+        data.frame(extraOut)
+      }, error = function(e) NA)
     } else extra.obs <- data.frame(NULL)
   }
   options(warn = old_warn)
@@ -1509,21 +1524,36 @@ permuteOnce.mimic <- function(i, d, G, con, uncon, null, param, freeParam,
   } else {
     availableArgs$con <- out0
     if (exists("out.null")) availableArgs$null <- out.null
-    AFI <- do.call(getAFIs, availableArgs)
+    # Wrap get AFIs so errrors don't kill call
+    AFI <- tryCatch(
+      do.call(getAFIs, availableArgs),
+      error = function(e) {
+        allAFIs <- c(AFIs, moreAFIs)
+        out <- rep(NA_real_, sum(!is.na(allAFIs)))
+        names(out) <- allAFIs[!is.na(allAFIs)]
+        out
+      }
+    )
     if (is.null(param)) {
       MI <- NULL
     } else {
-      MI <- max(do.call(getMIs, c(availableArgs, modelType = "mimic"))$X2)
+      # wrap getMIs so the whole thing doesn't crash if this fails
+      MI <- tryCatch(
+        max(do.call(getMIs, c(availableArgs, modelType = "mimic"))$X2),
+        error = function(e) NA_real_
+      )
     }
     ## anything extra?
     if (!is.null(extra)) {
-      extraArgs <- formals(extra)
-      neededArgs <- intersect(names(extraArgs), names(availableArgs))
-      extraArgs <- do.call(c, lapply(neededArgs, function(nn) availableArgs[nn]))
-      extraOut <- do.call(extra, extraArgs)
-      ## coerce extraOut to data.frame
-      if (!is.list(extraOut)) extraOut <- as.list(extraOut)
-      extra.obs <- data.frame(extraOut)
+      extra.obs <- tryCatch({
+        extraArgs <- formals(extra)
+        neededArgs <- intersect(names(extraArgs), names(availableArgs))
+        extraArgs <- do.call(c, lapply(neededArgs, function(nn) availableArgs[nn]))
+        extraOut <- do.call(extra, extraArgs)
+        ## coerce extraOut to data.frame
+        if (!is.list(extraOut)) extraOut <- as.list(extraOut)
+        data.frame(extraOut)
+      }, error = function(e) NA)
     } else extra.obs <- data.frame(NULL)
   }
   options(warn = old_warn)

--- a/semTools/R/permuteMeasEq.R
+++ b/semTools/R/permuteMeasEq.R
@@ -1524,7 +1524,7 @@ permuteOnce.mimic <- function(i, d, G, con, uncon, null, param, freeParam,
   } else {
     availableArgs$con <- out0
     if (exists("out.null")) availableArgs$null <- out.null
-    # Wrap get AFIs so errrors don't kill call
+    # Wrap getAFIs so errors don't kill worker
     AFI <- tryCatch(
       do.call(getAFIs, availableArgs),
       error = function(e) {
@@ -1537,7 +1537,7 @@ permuteOnce.mimic <- function(i, d, G, con, uncon, null, param, freeParam,
     if (is.null(param)) {
       MI <- NULL
     } else {
-      # wrap getMIs so the whole thing doesn't crash if this fails
+      # wrap getMIs so errors don't kill worker
       MI <- tryCatch(
         max(do.call(getMIs, c(availableArgs, modelType = "mimic"))$X2),
         error = function(e) NA_real_


### PR DESCRIPTION
When `getAFIs` (calling `lavaan::fitMeasures`) or `getMIs` (`calling lavaan::lavTestScore`) errors during a permutation iteration — for example due to `LAPACK dgesdd` failures on numerically pathological score-test matrices, see Reference-LAPACK/lapack#672 — the unhandled error kills the worker. Under `parallelType = "multicore"` this causes `mclapply` to return a `try-error` for that permutation, which then crashes the aggregation at line ~990 with `Error in x$AFI : $ operator is invalid for atomic vectors`.

The fix wraps both calls in `tryCatch` with the same NA fallback that the function already uses for the sparse/nonconv branch (lines 1404–1410), so a single bad permutation contributes NA to the null distribution rather than terminating the entire call. I applied the same change to `permuteOnce.mimic` for consistency. 

Note that I didn't add a new counter for something like `n.LapackFail`, so the `n.nonConverged` counter will be under-counting the true number of failures. I kept this initial proposed fix as narrow in scope as possible, but I can try to add an additional failure counter if you'd like.